### PR TITLE
Track 3 Tier 3: Optimistic-resolution settings, persistent reservations, Reserve pickers, PostgreSQL beta, save-as-blueprint endpoints

### DIFF
--- a/docs/admin/setting-up-cloudshell/cloudshell-configuration-options/customer-configuration-keys-repository/abstract-resources.md
+++ b/docs/admin/setting-up-cloudshell/cloudshell-configuration-options/customer-configuration-keys-repository/abstract-resources.md
@@ -63,3 +63,35 @@ sidebar_position: 1
 		</tr>
 	</tbody>
 </table>
+
+## Abstract resource resolution strategy
+When CloudShell reserves a sandbox, it resolves each abstract resource requirement to a concrete resource. By default (`Legacy`), all abstract resolution runs under a single global lock, so concurrent reservation requests are handled one at a time. Setting the strategy to `Optimistic` enables an opt-in solver that resolves abstract requirements outside that global lock and validates the result before committing, improving throughput when many reservations run concurrently. On `Legacy`, resolution behavior is unchanged. After changing this key, restart the CloudShell Server for it to take effect.
+
+<table>
+	<tbody>
+		<tr>
+			<td>Key</td>
+			<td>`<add key="AbstractResolutionStrategy" value="Optimistic"/>`</td>
+		</tr>
+		<tr>
+			<td>Possible values</td>
+			<td>Legacy/Optimistic</td>
+		</tr>
+		<tr>
+			<td>Where to add/change</td>
+			<td>`customer.config` CloudShell Server installation directory (requires a CloudShell Server service restart)</td>
+		</tr>
+		<tr>
+			<td>Default value</td>
+			<td>Legacy</td>
+		</tr>
+		<tr>
+			<td>Affected CloudShell Component</td>
+			<td>CloudShell Server</td>
+		</tr>
+		<tr>
+			<td>Version</td>
+			<td>2026.1 and above</td>
+		</tr>
+	</tbody>
+</table>

--- a/docs/admin/setting-up-cloudshell/cloudshell-configuration-options/customer-configuration-keys-repository/connectivity-management-and-route-configuration.md
+++ b/docs/admin/setting-up-cloudshell/cloudshell-configuration-options/customer-configuration-keys-repository/connectivity-management-and-route-configuration.md
@@ -64,6 +64,41 @@ sidebar_position: 4
 	</tbody>
 </table>
 
+## Select the network route resolution strategy
+
+By default, CloudShell resolves network routes under a single, server-wide lock, so concurrent route resolutions run one at a time. Setting this key to `Optimistic` enables an opt-in resolver that performs the route-resolution work outside that global lock and commits the result using optimistic concurrency (it validates and, if another reservation claimed a needed resource in the meantime, retries). This allows multiple route resolutions to proceed in parallel, which can increase route-resolution throughput when many reservations resolve routes at the same time. The default `Legacy` strategy preserves the original single-lock behavior. Any unrecognized value falls back to `Legacy`.
+
+Changing this key requires a restart of the CloudShell Server.
+
+<table>
+	<tbody>
+		<tr>
+			<td>Key</td>
+			<td>`<add key="NetworkRouteResolverStrategy" value="Optimistic"/>`</td>
+		</tr>
+		<tr>
+			<td>Possible values</td>
+			<td>Legacy/Optimistic</td>
+		</tr>
+		<tr>
+			<td>Where to add/change</td>
+			<td>`customer.config` CloudShell Server installation directory</td>
+		</tr>
+		<tr>
+			<td>Default value</td>
+			<td>Legacy</td>
+		</tr>
+		<tr>
+			<td>Affected CloudShell Component</td>
+			<td>CloudShell Server</td>
+		</tr>
+		<tr>
+			<td>Version</td>
+			<td>2026.1 and above</td>
+		</tr>
+	</tbody>
+</table>
+
 ## Enable regular users to change their email address
 <table>
 	<tbody>

--- a/docs/api-guide/shell-dev-blueprint-design-api/testshell-api.md
+++ b/docs/api-guide/shell-dev-blueprint-design-api/testshell-api.md
@@ -51,3 +51,31 @@ Once the scenario is created, it can be run automatically.
 - Many operations have two versions, a "single” version and a "bulk” version. For example, it is possible to create a single resource using the "CreateResource" method or to create many resources at once using the "CreateResources” operation. This is not always the fastest way performance-wise, but it is sometime easier to write and edit. The bulk operation usually gets a matrix as an input, and sometimes has special rules (such as the fact you cannot have the sub-resource creation line before the resource line).
 - Any function that requires a resource full path can also get the resource name without the folders it is located in.
 :::
+
+## Working with persistent reservations
+
+In addition to standard timed reservations, TestShell API can work with **persistent reservations** (persistent sandboxes). A persistent sandbox does not have a fixed end time and remains reserved until you explicitly end it or convert it back to a timed reservation.
+
+Persistence is controlled through the **`UpdateReservationEndTime`** method rather than a dedicated create method. The method takes the following parameters:
+
+- **`reservationId`** – The ID of the reservation to update.
+- **`isPersistent`** – A `Yes`/`No` value that sets whether the sandbox is persistent.
+- **`endTime`** – The new end time for the reservation.
+
+### Making a reservation persistent
+
+To convert an existing timed reservation into a persistent one, call `UpdateReservationEndTime` with `isPersistent` set to `Yes`. Since a persistent sandbox has no fixed end time, the `endTime` value is not applied and can be left empty.
+
+Note the following behavior:
+
+- A sandbox that is already persistent cannot be set to persistent again. Attempting to do so returns an error, because a persistent sandbox's end time cannot be changed.
+
+### Converting a persistent reservation back to a timed reservation
+
+To turn a persistent sandbox back into a standard timed reservation, call `UpdateReservationEndTime` with `isPersistent` set to `No` and provide a valid `endTime`. The end time must be later than the current time; otherwise the call fails.
+
+After this operation, the reservation is no longer persistent and ends at the specified end time.
+
+:::note
+The `CreateReservation` and `CreateImmediateReservation` methods do not include a persistence flag. To make a sandbox persistent, first create the reservation and then update it with `UpdateReservationEndTime` as described above. The exact method availability may depend on your CloudShell version.
+:::

--- a/docs/install-configure/cloudshell-suite/complete-install/install-cloudshell/select-database-type/index.md
+++ b/docs/install-configure/cloudshell-suite/complete-install/install-cloudshell/select-database-type/index.md
@@ -24,6 +24,10 @@ For more information, see [New Job Scheduling Architecture](../../../new-jss-ins
     :::tip
     For high load systems, we recommend using an SQL Server that is hosted on a separate machine (not Quali Server).
     :::
+
+    :::note PostgreSQL (Beta)
+    Starting with CloudShell 2025.1, PostgreSQL is available as an alternative relational database backend to SQL Server, **in Beta (evaluation only)**. Contact Quali Support for evaluation access. For details, see [Database Prerequisites](../../../../cs-system-requirements/database-prereq.md#postgresql-database-support-beta).
+    :::
     
 3. Select the MongoDB to use (create on-the-fly on the Quali Server or use an external MongoDB instance/cluster). CloudShell officially supports Mongo 4.2 and above (Community and Enterprise editions).
     

--- a/docs/install-configure/cs-system-requirements/database-prereq.md
+++ b/docs/install-configure/cs-system-requirements/database-prereq.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Database Prerequisites
 
-CloudShell applications can work with MS SQL database.
+CloudShell applications work with Microsoft SQL Server as the primary relational database backend. Starting with CloudShell 2025.1, **PostgreSQL is also available as an alternative relational database backend, in Beta**. For details, see [PostgreSQL database support (Beta)](#postgresql-database-support-beta) below.
 
 ## MongoDB database permissions and installation requirements
 
@@ -91,6 +91,19 @@ Installation instructions:
 
 Quali Server, SQL server or SQL Express, and the CloudShell applications can be installed on the same machine, or on separate machines in the same network.
 
+
+## PostgreSQL database support (Beta)
+
+:::note Beta
+Starting with CloudShell 2025.1, PostgreSQL is supported as an alternative relational database backend, **in Beta (evaluation only)**. It is intended for evaluation and is not yet recommended for production deployments. Microsoft SQL Server remains the default, fully supported relational database backend.
+:::
+
+To evaluate CloudShell on PostgreSQL, or to migrate an existing CloudShell SQL Server database to PostgreSQL, **contact Quali Support for evaluation access**. Quali Support will provide the required components, supported-version details, and setup and migration guidance for your CloudShell version.
+
+Notes:
+
+- PostgreSQL replaces only the SQL Server relational backend. CloudShell still uses MongoDB for the data described in [Select the Database Type](../cloudshell-suite/complete-install/install-cloudshell/select-database-type/index.md), regardless of whether the relational backend is SQL Server or PostgreSQL.
+- Because this feature is in Beta, the exact supported PostgreSQL versions and configuration steps depend on your CloudShell version and are provided by Quali Support as part of evaluation access.
 
 ## Additional requirements
 

--- a/docs/portal/blueprints/blueprint-catalog.md
+++ b/docs/portal/blueprints/blueprint-catalog.md
@@ -168,6 +168,10 @@ Blueprints of type ‘view’ cannot be reserved.
         
     3. Instead of changing the owner of the sandbox, you can permit additional users to use the sandbox. Click the Permitted Users section and select the users you wish to add.
         
+        :::note
+        In the Owner and Permitted Users pickers, the list of users is scoped to your current domain. When the domain has a large number of users, the picker loads users incrementally instead of loading them all up front - start typing a user name to search for and add users that are not shown in the initial list.
+        :::
+        
     4. To prevent users from ending the sandbox before its scheduled end time, enable Termination Protection. This option ensures your sandbox isn't ended accidentally or prematurely. And when you are ready to manually end the sandbox, disable the option in the sandbox's properties window and then end it.
     5. You can configure CloudShell to send email notifications to the owner of the sandbox and permitted users.
         

--- a/docs/portal/sandboxes/creating-sandboxes.md
+++ b/docs/portal/sandboxes/creating-sandboxes.md
@@ -65,6 +65,10 @@ Blueprints of type ‘view’ cannot be reserved.
         
     3. Instead of changing the owner of the sandbox, you can permit additional users to use the sandbox. Click the **Permitted Users** section and select the users you wish to add.
         
+        :::note
+        In the **Owner** and **Permitted Users** pickers, the list of users is scoped to your current domain. When the domain has a large number of users, the picker loads users incrementally instead of loading them all up front - start typing a user name to search for and add users that are not shown in the initial list.
+        :::
+        
     4. To prevent users from ending the sandbox before its scheduled end time, enable **Termination Protection**. This option ensures your sandbox isn't ended accidentally or prematurely. And when you are ready to manually end the sandbox, disable the option in the sandbox's properties window and then end it.
     5. You can configure CloudShell to send email notifications to the owner of the sandbox and permitted users.
         

--- a/docs/portal/sandboxes/sandbox-workspace/save-sandbox-as-blueprint.md
+++ b/docs/portal/sandboxes/sandbox-workspace/save-sandbox-as-blueprint.md
@@ -20,3 +20,7 @@ CloudShell also provides the option of creating a saved sandbox. However, unlike
     The new blueprint's properties page is displayed.
     
 3. Make the necessary changes and click **Update** at the bottom right of the page.
+
+:::note
+When you save the sandbox as a blueprint, connections (routes) whose endpoint is not a resource — for example, a route to an abstract or otherwise non-resource endpoint — are preserved in the resulting blueprint. Previously, such routes could prevent the sandbox from being saved.
+:::


### PR DESCRIPTION
Closes the remaining **STALE** how-to gaps from the coverage audit — the last of the 15-item backlog.

## Changes
- **Config keys** — `AbstractResolutionStrategy` (in `abstract-resources.md`) and `NetworkRouteResolverStrategy` (in `connectivity-management-and-route-configuration.md`): opt-in `Optimistic` solvers, `Legacy` default, CloudShell Server / `customer.config`, restart required (2026.1).
- **Persistent reservations** (`shell-dev-blueprint-design-api/testshell-api.md`) — new section documenting the real mechanism: `UpdateReservationEndTime(reservationId, isPersistent, endTime)` to make a sandbox persistent or revert it to timed (not a create-time flag).
- **Reserve dialog pickers** (`blueprint-catalog.md`, `creating-sandboxes.md`) — note that Owner / Permitted-Users use a server-side type-ahead lookup for large domains.
- **PostgreSQL (Beta)** (`cs-system-requirements/database-prereq.md`, DB-selection page) — added as a Beta/evaluation backend (contact Quali Support).
- **Assembly Lab save-as-blueprint** (`save-sandbox-as-blueprint.md`) — routes whose endpoint is not a resource are preserved on save.

## Grounding & validation
- Every config-key name/default, API signature, and behavior verified against Trunk code + integration tests, then adversarially re-checked (e.g. the optimistic keys confirmed in `ServiceConfigSettingsLoader`; persistence confirmed to be an update-only operation).
- `npm run build` passes (only the 3 pre-existing `abstract-resources.md` broken links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)